### PR TITLE
Show sensible error if not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Silence errors with `ruff`
 
+### Fixed
+
+- Show helpful error message if the linting tool is not installed
+
+  Until this release, if the tool you were trying to use to find errors wasn't
+  installed, this tool would succeed with a 'no errors found' message. This is
+  unhelpful, so we now show the 'No module named ...' error from Python and exit
+  with a non-zero return code.
+
 ## 1.0.0 (2023-11-17)
 
 This tool replaces

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,4 +3,5 @@ coverage
 fixit
 flake8
 pytest
+pytest-subprocess
 ruff

--- a/tests/silence_lint_error/flake8_test.py
+++ b/tests/silence_lint_error/flake8_test.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 import pytest
+from pytest_subprocess import FakeProcess
 
 from silence_lint_error.silence_lint_error import main
 
@@ -60,4 +62,23 @@ def foo():
     assert captured.err == """\
 -> finding errors with flake8
 no errors found
+"""
+
+
+def test_not_installed(capsys: pytest.CaptureFixture[str]):
+    with FakeProcess() as process:
+        process.register(
+            (sys.executable, '-mflake8', process.any()),
+            returncode=1, stderr='/path/to/python3: No module named flake8\n',
+        )
+
+        ret = main(('flake8', 'F401', 'path/to/file.py'))
+
+    assert ret == 1
+
+    captured = capsys.readouterr()
+    assert captured.out == ''
+    assert captured.err == """\
+-> finding errors with flake8
+ERROR: /path/to/python3: No module named flake8
 """

--- a/tests/silence_lint_error/ruff_test.py
+++ b/tests/silence_lint_error/ruff_test.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 import pytest
+from pytest_subprocess import FakeProcess
 
 from silence_lint_error.silence_lint_error import main
 
@@ -58,4 +60,23 @@ def foo():
     assert captured.err == """\
 -> finding errors with ruff
 no errors found
+"""
+
+
+def test_not_installed(capsys: pytest.CaptureFixture[str]):
+    with FakeProcess() as process:
+        process.register(
+            (sys.executable, '-mruff', process.any()),
+            returncode=1, stderr='/path/to/python3: No module named ruff\n',
+        )
+
+        ret = main(('ruff', 'F401', 'path/to/file.py'))
+
+    assert ret == 1
+
+    captured = capsys.readouterr()
+    assert captured.out == ''
+    assert captured.err == """\
+-> finding errors with ruff
+ERROR: /path/to/python3: No module named ruff
 """


### PR DESCRIPTION
Prior to this change, we would show 'no errors found' if the linting
tool did not run because it is not installed.

This change ensures we show a proper error message.
