### PR TITLE
Fix bug where `noqa` is added for all linters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Fixed
+
+- Fix bug where `noqa` is used for all linters' silence comments
+
+  We forgot to pass through the comment type when adding to existing comments.
+  These were always added as `noqa` comments, even for `fixit`.
+
 ## 1.2.0 (2023-12-11)
 
 ### Added

--- a/silence_lint_error/comments.py
+++ b/silence_lint_error/comments.py
@@ -27,7 +27,7 @@ def add_error_silencing_comments(
             continue
 
         if token.name == 'COMMENT':
-            new_comment = add_code_to_comment(token.src, 'noqa', error_code)
+            new_comment = add_code_to_comment(token.src, comment_type, error_code)
             tokens[idx] = tokens[idx]._replace(src=new_comment)
         else:
             tokens.insert(

--- a/tests/comments_test.py
+++ b/tests/comments_test.py
@@ -3,7 +3,60 @@ from __future__ import annotations
 import pytest
 
 from silence_lint_error.comments import add_code_to_comment
+from silence_lint_error.comments import add_error_silencing_comments
 from silence_lint_error.comments import add_noqa_comments
+
+
+def test_add_error_silencing_comments():
+    src = """\
+# a single-line statement on line 2
+foo = 'bar'
+
+# a function on line 5
+def baz(
+a: int,
+b: int,
+) -> str:
+...
+
+# a multi-line string on line 12
+s = '''
+hello there
+'''
+
+# a single-line statement with a pre-existing comment on line 17
+foo = 'bar'  # TODO: make this better
+
+# a single-line statement with a pre-existing ignore comment on line 20
+foo = 'bar'  # silence-me: DEF456
+"""
+
+    assert add_error_silencing_comments(
+        src, {2, 5, 12, 17, 20}, 'silence-me', 'ABC123',
+        # use 'silence-me' to ensure we haven't hard-coded any real
+        # linter-specific types
+    ) == """\
+# a single-line statement on line 2
+foo = 'bar'  # silence-me: ABC123
+
+# a function on line 5
+def baz(  # silence-me: ABC123
+a: int,
+b: int,
+) -> str:
+...
+
+# a multi-line string on line 12
+s = '''
+hello there
+'''  # silence-me: ABC123
+
+# a single-line statement with a pre-existing comment on line 17
+foo = 'bar'  # TODO: make this better  # silence-me: ABC123
+
+# a single-line statement with a pre-existing ignore comment on line 20
+foo = 'bar'  # silence-me: ABC123,DEF456
+"""
 
 
 def test_add_noqa_comments():


### PR DESCRIPTION
We forgot to pass through the comment type when adding to existing
comments. These were always added as `noqa` comments, even for `fixit`.
