### PR TITLE
Use full `ruff check` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Fixed
+
+- Use `ruff check` instead of `ruff` for running `ruff`.
+  This makes the tool compatible with ruff>=0.5.0.
+
 ## 1.4.1 (2024-05-09)
 
 The tests are no longer included in the built package.

--- a/silence_lint_error/linters/ruff.py
+++ b/silence_lint_error/linters/ruff.py
@@ -27,6 +27,7 @@ class Ruff:
         proc = subprocess.run(
             (
                 sys.executable, '-mruff',
+                'check',
                 '--select', rule_name,
                 '--output-format', 'json',
                 *filenames,


### PR DESCRIPTION
Older version of `ruff` allowed the checking to be done without an
explicit `check` command. That was removed in v0.5.0. This change
ensures we are invoking `ruff` correctly.
