### PR TITLE
ci parallel

### DIFF
--- a/.github/workflows/build_publish.yaml
+++ b/.github/workflows/build_publish.yaml
@@ -6,6 +6,11 @@ on:
     tags:
     - v*
 
+# Only allow one instance of this workflow for each PR.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -5,6 +5,11 @@ on:
     paths:
     - requirements*
 
+# Only allow one instance of this workflow for each PR.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   compile:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,3 +31,5 @@ jobs:
           tox.ini
     - run: python -m pip install tox
     - run: tox run-parallel --parallel-no-spinner
+      env:
+        FORCE_COLOR: true

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,5 +24,10 @@ jobs:
           3.11
           3.12
         allow-prereleases: true
+        cache: 'pip'
+        cache-dependency-path: |
+          requirements.txt
+          setup.cfg
+          tox.ini
     - run: python -m pip install tox
     - run: tox run-parallel --parallel-no-spinner

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,6 +1,9 @@
 name: tests
 
-on: [push]
+on:
+  pull_request:
+  push:
+    branches: [main]
 
 jobs:
   tests:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,15 +13,16 @@ concurrency:
 jobs:
   tests:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python: ['3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
-        python-version: ${{ matrix.python }}
+        python-version: |
+          3.9
+          3.10
+          3.11
+          3.12
         allow-prereleases: true
     - run: python -m pip install tox
-    - run: tox -e py
+    - run: tox run-parallel --parallel-no-spinner

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,6 +5,11 @@ on:
   push:
     branches: [main]
 
+# Only allow one instance of this workflow for each PR.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     runs-on: ubuntu-latest

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,11 @@
 envlist = py39,py310,py311,py312
 
 [testenv]
+# Install wheels instead of source distributions for faster execution.
+package = wheel
+# Share the build environment between tox environments.
+wheel_build_env = .pkg
+
 deps = -rrequirements.txt
 commands =
   coverage erase

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py39,py310,py311,py312
+envlist = py39,py310,py311,py312,report
 
 [testenv]
 # Install wheels instead of source distributions for faster execution.
@@ -9,6 +9,16 @@ wheel_build_env = .pkg
 
 deps = -rrequirements.txt
 commands =
+  coverage run --parallel-mode -m pytest {posargs:tests}
+
+[testenv:clean]
+skip_install = true
+commands =
   coverage erase
-  coverage run -m pytest {posargs:tests}
+
+[testenv:report]
+skip_install = true
+depends = py310,py311,py312
+commands =
+  coverage combine
   coverage report


### PR DESCRIPTION
- **Build a wheel to share between test run environments**
- ** Run `coverage` in parallel mode**
- **Only run tests for PRs and pushes to `main`**
- **Prevent concurrent test runs**
- **Run tests for all python versions in one job**
- **Cache Python dependencies**
- **Show tox/pytest output in color**
