### PR TITLE
Ignore syntax errors found by ruff >= 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Fixed
+
+- Handle syntax errors from `ruff>=0.8.0`.
+
 ## 1.5.0 (2024-08-27)
 
 ### Added

--- a/silence_lint_error/linters/ruff.py
+++ b/silence_lint_error/linters/ruff.py
@@ -43,6 +43,10 @@ class Ruff:
         all_violations = json.loads(proc.stdout)
         results: dict[FileName, list[Violation]] = defaultdict(list)
         for violation in all_violations:
+            if violation['code'] is None:
+                # ignore syntax errors while parsing the file
+                continue
+
             results[violation['filename']].append(
                 Violation(
                     rule_name=violation['code'],


### PR DESCRIPTION
In version 0.8.0, ruff stops reporting syntax errors as a rule violation
and reports the code as `None`. This causes a failure when we try to
sort the codes, to report "multiple errors found".

This change filters out those syntax errors because they are not rule
violations.

Co-authored-by: Charlie Denton <charlie@meshy.co.uk>
