### PR TITLE
Group testing dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
   directory: "/"
   schedule:
     interval: weekly
+  groups:
+    testing-dependencies:
+      patterns:
+        - "*"  # group all updates


### PR DESCRIPTION
We only need one PR per week to keep these up to date.
