### PR TITLE
Do not require tools to be installed in the same virtual environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Changed
+
+- No longer require `fixit`, `flake8`, and `ruff`
+  to be installed in the same virtual environment
+  as `silence-lint-error`.
+  The tool will now invoke the tasks directly,
+  using whichever version is available.
+  This matches thebehaviour for `semgrep` and `mypy`.
+
 ## 1.5.1 (2024-11-27)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ Install with pip:
 python -m pip install silence-lint-error
 ```
 
-You must also install the linting tool you wish to use
-*in the same virtual environment*.
+You must also install the linting tool you wish to use.
 
 ### silence linting errors
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # silence-lint-error
 
-Silent linting errors by adding `ignore` or `fixme` comments.
+Silent linting errors
+by adding `ignore` or `fixme` comments.
 
 This tool currently works with:
 
@@ -18,34 +19,41 @@ Install with pip:
 python -m pip install silence-lint-error
 ```
 
-You must also install the linting tool you wish to use *in the same virtual
-environment*.
+You must also install the linting tool you wish to use
+*in the same virtual environment*.
 
 ### silence linting errors
 
-Find linting errors and add the `ignore` or `fixme` comments as applicable.
+Find linting errors
+and add the `ignore` or `fixme` comments as applicable.
 
-For example, to add `lint-fixme: CollapseIsinstanceChecks` comments to ignore
-the `fixit.rules:CollapseIsinstanceChecks` rule from `fixit`, run:
+For example,
+to add `lint-fixme: CollapseIsinstanceChecks` comments
+to ignore the `fixit.rules:CollapseIsinstanceChecks` rule from `fixit`,
+run:
 
 ```shell
 silence-lint-error fixit fixit.rules:CollapseIsinstanceChecks path/to/files/ path/to/more/files/
 ```
 
-To add `noqa: F401` comments to ignore the `F401` rule in `flake8`, run:
+To add `noqa: F401` comments
+to ignore the `F401` rule in `flake8`,
+run:
 
 ```shell
 silence-lint-error flake8 F401 path/to/files/ path/to/more/files/
 ```
 
-To add `noqa: F401` comments to ignore the `F401` rule in `ruff`, run:
+To add `noqa: F401` comments
+to ignore the `F401` rule in `ruff`,
+run:
 
 ```shell
 silence-lint-error ruff F401 path/to/files/ path/to/more/files/
 ```
 
-To add `nosemgrep: python.lang.best-practice.sleep.arbitrary-sleep` comments to
-ignore the `python.lang.best-practice.sleep.arbitrary-sleep` rule in `semgrep`,
+To add `nosemgrep: python.lang.best-practice.sleep.arbitrary-sleep` comments
+to ignore the `python.lang.best-practice.sleep.arbitrary-sleep` rule in `semgrep`,
 run:
 
 ```shell
@@ -66,17 +74,22 @@ silence-lint-error mypy truthy-bool path/to/files/ path/to/more/files/
 
 ### fix silenced errors
 
-If there is an auto-fix for a linting error, you can remove the `ignore` or
-`fixme` comments and apply the auto-fix.
+If there is an auto-fix for a linting error,
+you can remove the `ignore` or `fixme` comments
+and apply the auto-fix.
 
-For example, to remove all `lint-fixme: CollapseIsinstanceChecks` comments and
-apply the auto-fix for that rule, run:
+For example
+to remove all `lint-fixme: CollapseIsinstanceChecks` comments
+and apply the auto-fix for that rule,
+run:
 
 ```shell
 fix-silenced-error fixit fixit.rules:CollapseIsinstanceChecks path/to/files/ path/to/more/files/
 ```
 
-To remove `noqa: F401` comments and apply the auto-fix for that rule, run:
+To remove `noqa: F401` comments
+and apply the auto-fix for that rule,
+run:
 
 ```shell
 fix-silenced-error ruff F401 path/to/files/ path/to/more/files/
@@ -84,13 +97,14 @@ fix-silenced-error ruff F401 path/to/files/ path/to/more/files/
 
 ## Rationale
 
-When adding a new rule (or enabling more rules) for a linter on a large
-code-base, fixing the existing violations can be too large a task to do quickly.
-However, starting to check the rule sooner will prevent new violations from
-being introduced.
+When adding a new rule (or enabling more rules) for a linter
+on a large code-base,
+fixing the existing violations can be too large a task to do quickly.
+However, starting to check the rule sooner
+will prevent new violations from being introduced.
 
 Ignoring existing violations is a quick way to allow new rules to be enabled.
 You can then burn down those existing violations over time.
 
-This tool makes it easy to find and ignore all current violations of a rule so
-that it can be enabled.
+This tool makes it easy to find and ignore all current violations of a rule
+so that it can be enabled.

--- a/silence_lint_error/linters/fixit.py
+++ b/silence_lint_error/linters/fixit.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import re
 import subprocess
-import sys
 from collections import defaultdict
 from collections.abc import Iterator
 from collections.abc import Sequence
@@ -30,7 +29,7 @@ class Fixit:
     ) -> dict[FileName, list[Violation]]:
         proc = subprocess.run(
             (
-                sys.executable, '-mfixit',
+                'fixit',
                 '--rules', rule_name,
                 'lint', *filenames,
             ),
@@ -113,7 +112,7 @@ class Fixit:
     ) -> tuple[int, str]:
         proc = subprocess.run(
             (
-                sys.executable, '-mfixit',
+                'fixit',
                 '--rules', rule_name,
                 'fix', '--automatic', *filenames,
             ),

--- a/silence_lint_error/linters/flake8.py
+++ b/silence_lint_error/linters/flake8.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import subprocess
-import sys
 from collections import defaultdict
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
@@ -25,7 +24,7 @@ class Flake8:
     ) -> dict[FileName, list[Violation]]:
         proc = subprocess.run(
             (
-                sys.executable, '-mflake8',
+                'flake8',
                 '--select', rule_name,
                 '--format', '%(path)s %(row)s',
                 *filenames,

--- a/silence_lint_error/linters/ruff.py
+++ b/silence_lint_error/linters/ruff.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 import subprocess
-import sys
 from collections import defaultdict
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
@@ -26,8 +25,7 @@ class Ruff:
     ) -> dict[FileName, list[Violation]]:
         proc = subprocess.run(
             (
-                sys.executable, '-mruff',
-                'check',
+                'ruff', 'check',
                 '--select', rule_name,
                 '--output-format', 'json',
                 *filenames,
@@ -73,8 +71,8 @@ class Ruff:
     ) -> tuple[int, str]:
         proc = subprocess.run(
             (
-                sys.executable, '-mruff',
-                'check', '--fix',
+                'ruff', 'check',
+                '--fix',
                 '--select', rule_name,
                 *filenames,
             ),

--- a/tests/cli/silence_lint_error_test.py
+++ b/tests/cli/silence_lint_error_test.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-import sys
 from pathlib import Path
 from unittest import mock
 
@@ -102,7 +101,7 @@ ERROR: errors found for multiple rules: ['CollapseIsinstanceChecks', 'NoStaticIf
     def test_not_installed(self, capsys: pytest.CaptureFixture[str]):
         with FakeProcess() as process:
             process.register(
-                (sys.executable, '-mfixit', process.any()),
+                ('fixit', process.any()),
                 returncode=1, stderr='/path/to/python3: No module named fixit\n',
             )
 
@@ -217,7 +216,7 @@ no errors found
     def test_not_installed(self, capsys: pytest.CaptureFixture[str]):
         with FakeProcess() as process:
             process.register(
-                (sys.executable, '-mflake8', process.any()),
+                ('flake8', process.any()),
                 returncode=1, stderr='/path/to/python3: No module named flake8\n',
             )
 
@@ -325,7 +324,7 @@ found errors in 1 files
     def test_not_installed(self, capsys: pytest.CaptureFixture[str]):
         with FakeProcess() as process:
             process.register(
-                (sys.executable, '-mruff', process.any()),
+                ('ruff', process.any()),
                 returncode=1, stderr='/path/to/python3: No module named ruff\n',
             )
 


### PR DESCRIPTION
This is not required for `semgrep` and `mypy` -- the former cannot be
invoked with `python -m`. In that regard, the advice in the README was
misleading. There is no reason to require the tools to beinstalled in
the same virtual environment. The requirement makes this tool awkward to
use with `pipx` or `uvx`.

For all these reasons, this change removes that restriction for `fixit`,
`flake8`, and `ruff`.

Resolves #86