### PR TITLE
Improve semgrep usage docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ dist/
 
 venv/
 
+.idea/
+
 .tox/
 .coverage
 .coverage.*

--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ see the `--config` entry in the [`semgrep` documentation](https://semgrep.dev/do
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; |____ rule.yml/<br>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;|____typing_rules<br>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;  |___another_rule.yml
-> 
+>
 > If you run semgrep from within `project_root` with `SEMGREP_RULES=./semgrep/typing_rules`, `{namespace-prefix}` will take the value of `semgrep.typing_rules`<br>
-> 
+>
 > The command to run would then become
 > ```shell
 > SEMGREP_RULES=./semgrep/typing_rules silence-lint-error semgrep semgrep.typing_rules.rule_name ./src

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This tool currently works with:
 - [`ruff`](https://docs.astral.sh/ruff/)
 - [`semgrep`](https://semgrep.dev/docs/) (silence only)
 
-## Usage
+# Usage
 
 Install with pip:
 
@@ -21,20 +21,21 @@ python -m pip install silence-lint-error
 
 You must also install the linting tool you wish to use.
 
-### silence linting errors
+## silence linting errors
 
 Find linting errors
 and add the `ignore` or `fixme` comments as applicable.
 
-For example,
-to add `lint-fixme: CollapseIsinstanceChecks` comments
+### Fixit
+
+To add `lint-fixme: CollapseIsinstanceChecks` comments
 to ignore the `fixit.rules:CollapseIsinstanceChecks` rule from `fixit`,
 run:
 
 ```shell
 silence-lint-error fixit fixit.rules:CollapseIsinstanceChecks path/to/files/ path/to/more/files/
 ```
-
+### Flake8
 To add `noqa: F401` comments
 to ignore the `F401` rule in `flake8`,
 run:
@@ -43,6 +44,8 @@ run:
 silence-lint-error flake8 F401 path/to/files/ path/to/more/files/
 ```
 
+### Ruff
+
 To add `noqa: F401` comments
 to ignore the `F401` rule in `ruff`,
 run:
@@ -50,6 +53,8 @@ run:
 ```shell
 silence-lint-error ruff F401 path/to/files/ path/to/more/files/
 ```
+
+### Semgrep
 
 To add `nosemgrep: python.lang.best-practice.sleep.arbitrary-sleep` comments
 to ignore the `python.lang.best-practice.sleep.arbitrary-sleep` rule in `semgrep`,
@@ -63,6 +68,7 @@ N.B. The rules must be configured in an environment variable.
 For more information about configuring semgrep rules,
 see the `--config` entry in the [`semgrep` documentation](https://semgrep.dev/docs/cli-reference-oss/)
 
+### Mypy
 To add `type: ignore` comments
 to ignore the `truthy-bool` error from `mypy`,
 run:
@@ -71,7 +77,8 @@ run:
 silence-lint-error mypy truthy-bool path/to/files/ path/to/more/files/
 ```
 
-### fix silenced errors
+## fix silenced errors
+
 
 If there is an auto-fix for a linting error,
 you can remove the `ignore` or `fixme` comments

--- a/README.md
+++ b/README.md
@@ -56,17 +56,35 @@ silence-lint-error ruff F401 path/to/files/ path/to/more/files/
 
 ### Semgrep
 
-To add `nosemgrep: python.lang.best-practice.sleep.arbitrary-sleep` comments
-to ignore the `python.lang.best-practice.sleep.arbitrary-sleep` rule in `semgrep`,
+To add `nosemgrep: {namespace-prefix}.best-practice.sleep.arbitrary-sleep` comments
+to ignore the `{namespace-prefix}.best-practice.sleep.arbitrary-sleep` rule in `semgrep`,
 run:
 
 ```shell
-SEMGREP_RULES=r/python silence-lint-error semgrep python.lang.best-practice.sleep.arbitrary-sleep path/to/files/ path/to/more/files/
+SEMGREP_RULES=r/python silence-lint-error semgrep {namespace-prefix}.best-practice.sleep.arbitrary-sleep path/to/files/ path/to/more/files/
 ```
 
-N.B. The rules must be configured in an environment variable.
-For more information about configuring semgrep rules,
+> The rules must be configured in the `SEMGREP_RULES` environment variable. <br>
+> For more information about configuring semgrep rules,
 see the `--config` entry in the [`semgrep` documentation](https://semgrep.dev/docs/cli-reference-oss/)
+
+
+> Semgrep sort of namespaces the rules based on the name of the directory. For example, if you have this folder structure: <br>
+> <br>
+└── project_root/<br>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;|____ src<br>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; |____ semgrep/<br>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; |____ rule.yml/<br>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;|____typing_rules<br>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;  |___another_rule.yml
+> 
+> If you run semgrep from within `project_root` with `SEMGREP_RULES=./semgrep/typing_rules`, `{namespace-prefix}` will take the value of `semgrep.typing_rules`<br>
+> 
+> The command to run would then become
+> ```shell
+> SEMGREP_RULES=./semgrep/typing_rules silence-lint-error semgrep semgrep.typing_rules.rule_name ./src
+> ```
+
 
 ### Mypy
 To add `type: ignore` comments


### PR DESCRIPTION
This adds a small section explaining how semgrep identifies/locates rules via directory namespace.

The reason for explaining this further is that because passing the wrong pefix/ omitting it (like i did), will yield no results, and it's not straightforward to know this because semgrep doesn't document it.
