### PR TITLE
Disable auto-fix in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+ci:
+    autofix_prs: false
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0


### PR DESCRIPTION
This makes pre-commit.ci a regular CI runner and does not allow it to
push fixes back onto PR branches. I would rather we fixed the changes in
the original PR.
