### PR TITLE
Combine error codes in `nosemgrep` comments

### DIFF
--- a/silence_lint_error/comments.py
+++ b/silence_lint_error/comments.py
@@ -58,7 +58,9 @@ def add_noqa_comments(src: str, lines: set[int], error_code: str) -> str:
     return add_error_silencing_comments(src, lines, 'noqa', error_code)
 
 
-def add_code_to_comment(comment: str, comment_type: str, code: str) -> str:
+def add_code_to_comment(
+        comment: str, comment_type: str, code: str, sep: str = '',
+) -> str:
     """Add to a comment to make it a error-silencing comment.
 
     If the comment already includes an error silencing section of the same type, this
@@ -66,7 +68,7 @@ def add_code_to_comment(comment: str, comment_type: str, code: str) -> str:
     """
     if f'{comment_type}: ' in comment:
         return comment.replace(
-            f'{comment_type}: ', f'{comment_type}: {code},', 1,
+            f'{comment_type}: ', f'{comment_type}: {code},{sep}', 1,
         )
     else:
         return comment + f'  # {comment_type}: {code}'

--- a/tests/linters/semgrep_test.py
+++ b/tests/linters/semgrep_test.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from silence_lint_error.linters import semgrep
+from silence_lint_error.silencing import Violation
+
+
+class TestSilenceViolations:
+    def test_add_to_existing_silence_comment(self) -> None:
+        src = """\
+# nosemgrep: some-error-code
+violation_here()
+"""
+        violation = Violation(
+            rule_name='another-error-code',
+            lineno=2,
+        )
+
+        modified_src = semgrep.Semgrep().silence_violations(
+            src, (violation,),
+        )
+
+        assert modified_src == """\
+# nosemgrep: another-error-code, some-error-code
+violation_here()
+"""


### PR DESCRIPTION
Before this change, if a line violates 2 rules, `silence-lint-error`
would stack the ignore comments:

```python
this_violates_two_rules()
```

However, semgrep does not recognise these stacked comments and will only
apply the rule from the line immediately above the violation. In this
case, a violation of `rule-one` will be reported.

This change detects existing `nosemgrep` comments above a violation and
will combine the two codes:

```python
this_violates_two_rules()
```

Fixes #128 
